### PR TITLE
Include missing esp_err header for BSP display

### DIFF
--- a/components/settings/settings.c
+++ b/components/settings/settings.c
@@ -1,5 +1,6 @@
 #include "settings.h"
 #include "esp_log.h"
+#include "esp_err.h"
 #include "bsp/display.h"
 
 static const char *TAG = "SETTINGS";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2,6 +2,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 #include "esp_log.h"
+#include "esp_err.h"
 #include "lvgl.h"
 #include "bsp/esp-bsp.h"
 #include "bsp/display.h"


### PR DESCRIPTION
## Summary
- ensure esp_err_t type is available by including esp_err.h before BSP display headers

## Testing
- `idf.py build` *(fails: cmake process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689cb16e55a0833280ac2321d2623131