### PR TITLE
Fix Nordic UART JSON reception

### DIFF
--- a/components/ble_sync/ble_sync.c
+++ b/components/ble_sync/ble_sync.c
@@ -34,6 +34,11 @@ void uartTask(void *parameter) {
         mbuf[item_size] = '\0';
         vRingbufferReturnItem(nordic_uart_rx_buf_handle, (void *)item);
 
+        // Ignore control messages (e.g., disconnect marker)
+        if (mbuf[0] == '\003') {
+          continue;
+        }
+
         ESP_LOGI(TAG, "Received: %s", mbuf);
 
         cJSON *root = cJSON_Parse(mbuf);


### PR DESCRIPTION
## Summary
- remove custom CCCD descriptors to prevent disconnects
- skip control messages in BLE sync task so only JSON payloads are parsed

## Testing
- `idf.py build` *(fails: Cannot establish a connection to the component registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bd31657c8332908a2b3cbf02e55d