### PR TITLE
Initialize NimBLE controller and check start errors

### DIFF
--- a/components/ble_sync/ble_sync.c
+++ b/components/ble_sync/ble_sync.c
@@ -92,7 +92,10 @@ static void nordic_uart_callback(enum nordic_uart_callback_type callback_type) {
 
 esp_err_t ble_sync_init(void)
 {
-    nordic_uart_start("ESP32 S3 Watch", nordic_uart_callback);
+    esp_err_t err = nordic_uart_start("ESP32 S3 Watch", nordic_uart_callback);
+    if (err != ESP_OK) {
+        return err;
+    }
 
     xTaskCreate(uartTask, "uartTask", 4000, NULL, 5, NULL);
 


### PR DESCRIPTION
## Summary
- ensure NimBLE controller init/deinit around Nordic UART service
- check nordic_uart_start in BLE sync initialization

## Testing
- `idf.py build` *(fails: Cannot establish a connection to the component registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e9ea85f083329c0a798e50942dc5