### PR TITLE
Add display timeout and wake button

### DIFF
--- a/components/display_manager/CMakeLists.txt
+++ b/components/display_manager/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "display_manager.c"
+    INCLUDE_DIRS "include"
+    REQUIRES lvgl settings waveshare__esp32_s3_touch_amoled_2_06
+)

--- a/components/display_manager/display_manager.c
+++ b/components/display_manager/display_manager.c
@@ -1,0 +1,88 @@
+#include "display_manager.h"
+#include "bsp/display.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "lvgl.h"
+#include "settings.h"
+#include "esp_log.h"
+
+#define DISPLAY_BUTTON GPIO_NUM_0
+
+static const char *TAG = "DISPLAY_MGR";
+
+static bool display_on = true;
+static uint32_t timeout_ms;
+
+static void display_turn_off_internal(void) {
+    if (!display_on) {
+        return;
+    }
+    ESP_LOGI(TAG, "Turning display off");
+    bsp_display_brightness_set(0);
+    display_on = false;
+}
+
+void display_manager_turn_off(void) {
+    display_turn_off_internal();
+}
+
+void display_manager_turn_on(void) {
+    if (!display_on) {
+        ESP_LOGI(TAG, "Turning display on");
+        bsp_display_brightness_set(settings_get_brightness());
+        display_on = true;
+    }
+    display_manager_reset_timer();
+}
+
+bool display_manager_is_on(void) {
+    return display_on;
+}
+
+void display_manager_reset_timer(void) {
+    lv_disp_trig_activity(NULL);
+}
+
+static void touch_event_cb(lv_event_t *e) {
+    display_manager_reset_timer();
+}
+
+static void display_manager_task(void *arg) {
+    while (1) {
+        if (display_on) {
+            uint32_t inactive = lv_disp_get_inactive_time(NULL);
+            if (inactive >= timeout_ms) {
+                display_turn_off_internal();
+            }
+            if (gpio_get_level(DISPLAY_BUTTON) == 0) {
+                display_manager_reset_timer();
+                vTaskDelay(pdMS_TO_TICKS(500));
+            }
+        } else {
+            if (gpio_get_level(DISPLAY_BUTTON) == 0) {
+                display_manager_turn_on();
+                vTaskDelay(pdMS_TO_TICKS(500));
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+}
+
+void display_manager_init(void) {
+    timeout_ms = settings_get_display_timeout();
+
+    gpio_config_t io_conf = {
+        .pin_bit_mask = 1ULL << DISPLAY_BUTTON,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&io_conf);
+
+    lv_obj_add_event_cb(lv_scr_act(), touch_event_cb, LV_EVENT_ALL, NULL);
+
+    xTaskCreate(display_manager_task, "display_mgr", 2048, NULL, 5, NULL);
+}
+

--- a/components/display_manager/idf_component.yml
+++ b/components/display_manager/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  waveshare/esp32_s3_touch_amoled_2_06: "*"

--- a/components/display_manager/include/display_manager.h
+++ b/components/display_manager/include/display_manager.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <stdbool.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void display_manager_init(void);
+void display_manager_turn_on(void);
+void display_manager_turn_off(void);
+bool display_manager_is_on(void);
+void display_manager_reset_timer(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/gui/CMakeLists.txt
+++ b/components/gui/CMakeLists.txt
@@ -24,5 +24,5 @@ idf_component_register(
     "icons/image_heart_bg_large.c"
     
     INCLUDE_DIRS "include" 
-    REQUIRES lvgl sensors settings
+    REQUIRES lvgl sensors settings display_manager
 )

--- a/components/gui/ui.c
+++ b/components/gui/ui.c
@@ -3,6 +3,7 @@
 #include "notifications.h"
 #include "settings_screen.h"
 #include "sensors.h"
+#include "display_manager.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -159,8 +160,9 @@ void ui_init(void) {
 void ui_task(void* pvParameters) {
     ESP_LOGI(TAG, "UI task started");
     ui_init();
+    display_manager_init();
     while (1) {
-        //lv_timer_handler();
+        lv_timer_handler();
         vTaskDelay(pdMS_TO_TICKS(50));
     }
 }

--- a/components/settings/include/settings.h
+++ b/components/settings/include/settings.h
@@ -5,9 +5,16 @@
 extern "C" {
 #endif
 
+#define SETTINGS_DISPLAY_TIMEOUT_10S 10000
+#define SETTINGS_DISPLAY_TIMEOUT_20S 20000
+#define SETTINGS_DISPLAY_TIMEOUT_30S 30000
+#define SETTINGS_DISPLAY_TIMEOUT_1MIN 60000
+
 void settings_init(void);
 void settings_set_brightness(uint8_t level);
 uint8_t settings_get_brightness(void);
+void settings_set_display_timeout(uint32_t timeout);
+uint32_t settings_get_display_timeout(void);
 void settings_set_sound(bool enabled);
 bool settings_get_sound(void);
 

--- a/components/settings/settings.c
+++ b/components/settings/settings.c
@@ -8,6 +8,7 @@
 
 static const char *TAG = "SETTINGS";
 static uint8_t brightness = 30;
+static uint32_t display_timeout_ms = 30000;
 static bool sound_enabled = true;
 
 void settings_init(void) {
@@ -40,6 +41,16 @@ void settings_set_brightness(uint8_t level) {
 
 uint8_t settings_get_brightness(void) {
     return brightness;
+}
+
+void settings_set_display_timeout(uint32_t timeout) {
+    if (timeout == 10000 || timeout == 20000 || timeout == 30000 || timeout == 60000) {
+        display_timeout_ms = timeout;
+    }
+}
+
+uint32_t settings_get_display_timeout(void) {
+    return display_timeout_ms;
 }
 
 void settings_set_sound(bool enabled) {


### PR DESCRIPTION
## Summary
- add display_manager component to control screen power and wake on GPIO0
- expose configurable display timeout in settings
- run LVGL timer and init display manager from UI task

## Testing
- `idf.py build` *(fails: Cannot establish a connection to the component registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a19ba8b44483328ad85092436ca764