### PR TITLE
refactor: prioritize UI tasks for responsiveness

### DIFF
--- a/components/display_manager/display_manager.c
+++ b/components/display_manager/display_manager.c
@@ -1,29 +1,29 @@
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "esp_check.h"
-#include "esp_err.h"
-#include "esp_log.h"
 #include "display_manager.h"
 #include "bsp/display.h"
 #include "bsp/esp32_s3_touch_amoled_2_06.h"
+#include "driver/gpio.h"
+#include "esp_check.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_lvgl_port.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "driver/gpio.h"
 #include "lvgl.h"
-#include "esp_lvgl_port.h"
-#include "settings.h"
 #include "nimble-nordic-uart.h"
+#include "settings.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 // Power management
-#include "sdkconfig.h"
 #include "esp_sleep.h"
+#include "sdkconfig.h"
 #if CONFIG_PM_ENABLE
 #include "esp_pm.h"
 #endif
 
-
 // If the board provides simple GPIO buttons, use one as wake key.
-// On this hardware BSP_CAPS_BUTTONS is 0, so we will use the PMU PWR key instead.
+// On this hardware BSP_CAPS_BUTTONS is 0, so we will use the PMU PWR key
+// instead.
 #define DISPLAY_BUTTON GPIO_NUM_0
 
 static const char *TAG = "DISPLAY_MGR";
@@ -35,203 +35,201 @@ static esp_pm_lock_handle_t s_no_ls_lock = NULL;
 #endif
 
 static void display_turn_off_internal(void) {
-    if (!display_on) {
-        return;
-    }
-    ESP_LOGI(TAG, "Turning display off");
-    // Stop LVGL timers to pause flushing while panel sleeps. Take LVGL lock to avoid in-flight flush.
-    if (lvgl_port_lock(200)) {
-        lvgl_port_stop();
-        lvgl_port_unlock();
-    } else {
-        lvgl_port_stop();
-    }
-    // Disable touch input polling and optionally hold touch in reset
-    lv_indev_t* indev = bsp_display_get_input_dev();
+  if (!display_on) {
+    return;
+  }
+  ESP_LOGI(TAG, "Turning display off");
+  // Stop LVGL timers to pause flushing while panel sleeps. Take LVGL lock to
+  // avoid in-flight flush.
+  if (lvgl_port_lock(200)) {
+    lvgl_port_stop();
+    lvgl_port_unlock();
+  } else {
+    lvgl_port_stop();
+  }
+  // Disable touch input polling and optionally hold touch in reset
+  lv_indev_t *indev = bsp_display_get_input_dev();
+  if (indev) {
+    lv_indev_enable(indev, false);
+  }
+#if defined(BSP_LCD_TOUCH_RST)
+  gpio_set_direction(BSP_LCD_TOUCH_RST, GPIO_MODE_OUTPUT);
+  gpio_set_level(BSP_LCD_TOUCH_RST, 0);
+#endif
+  // Put panel into low-power sleep and ensure backlight is off
+  bsp_display_sleep();
+  bsp_display_brightness_set(0);
+  // Hint BLE to prefer low-power connection parameters while screen is off
+  nordic_uart_set_low_power_mode(true);
+  // Allow automatic light sleep while the screen is off
+#if CONFIG_PM_ENABLE
+  if (s_no_ls_lock) {
+    (void)esp_pm_lock_release(s_no_ls_lock);
+  }
+#endif
+  display_on = false;
+}
+
+void display_manager_turn_off(void) { display_turn_off_internal(); }
+
+void display_manager_turn_on(void) {
+  if (!display_on) {
+    ESP_LOGI(TAG, "Turning display on");
+    // Wake the panel first, then resume LVGL and restore brightness
+    bsp_display_wake();
+    lvgl_port_resume();
+    bsp_display_brightness_set(settings_get_brightness());
+    // Re-enable touch input and release touch reset
+    lv_indev_t *indev = bsp_display_get_input_dev();
     if (indev) {
-        lv_indev_enable(indev, false);
+      lv_indev_enable(indev, true);
     }
 #if defined(BSP_LCD_TOUCH_RST)
     gpio_set_direction(BSP_LCD_TOUCH_RST, GPIO_MODE_OUTPUT);
-    gpio_set_level(BSP_LCD_TOUCH_RST, 0);
+    gpio_set_level(BSP_LCD_TOUCH_RST, 1);
+    vTaskDelay(pdMS_TO_TICKS(5));
 #endif
-    // Put panel into low-power sleep and ensure backlight is off
-    bsp_display_sleep();
-    bsp_display_brightness_set(0);
-    // Hint BLE to prefer low-power connection parameters while screen is off
-    nordic_uart_set_low_power_mode(true);
-    // Allow automatic light sleep while the screen is off
+    display_on = true;
+  }
+  // Prevent light sleep while actively displaying UI for responsiveness
 #if CONFIG_PM_ENABLE
-    if (s_no_ls_lock) {
-        (void)esp_pm_lock_release(s_no_ls_lock);
-    }
+  if (s_no_ls_lock) {
+    (void)esp_pm_lock_acquire(s_no_ls_lock);
+  }
 #endif
-    display_on = false;
+  // Restore more responsive BLE params when screen is on
+  nordic_uart_set_low_power_mode(false);
+  display_manager_reset_timer();
 }
 
-void display_manager_turn_off(void) {
-    display_turn_off_internal();
-}
+bool display_manager_is_on(void) { return display_on; }
 
-void display_manager_turn_on(void) {
-    if (!display_on) {
-        ESP_LOGI(TAG, "Turning display on");
-        // Wake the panel first, then resume LVGL and restore brightness        
-        bsp_display_wake();
-        lvgl_port_resume();
-        bsp_display_brightness_set(settings_get_brightness());
-        // Re-enable touch input and release touch reset
-        lv_indev_t* indev = bsp_display_get_input_dev();
-        if (indev) {
-            lv_indev_enable(indev, true);
-        }
-#if defined(BSP_LCD_TOUCH_RST)
-        gpio_set_direction(BSP_LCD_TOUCH_RST, GPIO_MODE_OUTPUT);
-        gpio_set_level(BSP_LCD_TOUCH_RST, 1);
-        vTaskDelay(pdMS_TO_TICKS(5));
-#endif
-        display_on = true;
-    }
-    // Prevent light sleep while actively displaying UI for responsiveness
-#if CONFIG_PM_ENABLE
-    if (s_no_ls_lock) {
-        (void)esp_pm_lock_acquire(s_no_ls_lock);
-    }
-#endif
-    // Restore more responsive BLE params when screen is on
-    nordic_uart_set_low_power_mode(false);
-    display_manager_reset_timer();
-}
-
-bool display_manager_is_on(void) {
-    return display_on;
-}
-
-void display_manager_reset_timer(void) {
-    lv_disp_trig_activity(NULL);
-}
+void display_manager_reset_timer(void) { lv_disp_trig_activity(NULL); }
 
 static void touch_event_cb(lv_event_t *e) {
-    lv_event_code_t code = lv_event_get_code(e);
-    switch (code) {
-        case LV_EVENT_PRESSED:
-        case LV_EVENT_PRESSING:
-        case LV_EVENT_RELEASED:
-        case LV_EVENT_CLICKED:
-        case LV_EVENT_LONG_PRESSED:
-        case LV_EVENT_LONG_PRESSED_REPEAT:
-        case LV_EVENT_GESTURE:
-            display_manager_reset_timer();
-            break;
-        default:
-            break; // ignore non-input/render events
-    }
+  lv_event_code_t code = lv_event_get_code(e);
+  switch (code) {
+  case LV_EVENT_PRESSED:
+  case LV_EVENT_PRESSING:
+  case LV_EVENT_RELEASED:
+  case LV_EVENT_CLICKED:
+  case LV_EVENT_LONG_PRESSED:
+  case LV_EVENT_LONG_PRESSED_REPEAT:
+  case LV_EVENT_GESTURE:
+    display_manager_reset_timer();
+    break;
+  default:
+    break; // ignore non-input/render events
+  }
 }
 
-static bool wake_button_pressed(void)
-{
+static bool wake_button_pressed(void) {
 #if BSP_CAPS_BUTTONS
-    return gpio_get_level(DISPLAY_BUTTON) == 0;
+  return gpio_get_level(DISPLAY_BUTTON) == 0;
 #else
-    // Poll AXP2101 power key short-press event
-    return bsp_power_poll_pwr_button_short();
+  // Poll AXP2101 power key short-press event
+  return bsp_power_poll_pwr_button_short();
 #endif
 }
 
 static void display_manager_task(void *arg) {
-    ESP_LOGI(TAG, "Display manager task started");
-    while (1) {
-        // Refresh timeout from settings to apply changes immediately
-        timeout_ms = settings_get_display_timeout();
-        if (display_on) {
-            uint32_t inactive = lv_disp_get_inactive_time(NULL);
-            if (inactive >= timeout_ms) {
-                display_turn_off_internal();
-            }
-            if (wake_button_pressed()) {
-                display_manager_reset_timer();
-                vTaskDelay(pdMS_TO_TICKS(100));
-            }
-        } else {
-            if (wake_button_pressed()) {
-                display_manager_turn_on();
-                vTaskDelay(pdMS_TO_TICKS(100));
-            }
-        }
-        vTaskDelay(pdMS_TO_TICKS(50));
+  ESP_LOGI(TAG, "Display manager task started");
+  TickType_t last = xTaskGetTickCount();
+  while (1) {
+    // Refresh timeout from settings to apply changes immediately
+    timeout_ms = settings_get_display_timeout();
+    if (display_on) {
+      uint32_t inactive = lv_disp_get_inactive_time(NULL);
+      if (inactive >= timeout_ms) {
+        display_turn_off_internal();
+      }
+      if (wake_button_pressed()) {
+        display_manager_reset_timer();
+        vTaskDelay(pdMS_TO_TICKS(100));
+        last = xTaskGetTickCount();
+      }
+    } else {
+      if (wake_button_pressed()) {
+        display_manager_turn_on();
+        vTaskDelay(pdMS_TO_TICKS(100));
+        last = xTaskGetTickCount();
+      }
     }
+    vTaskDelayUntil(&last, pdMS_TO_TICKS(50));
+  }
 }
 
 void display_manager_init(void) {
-    timeout_ms = settings_get_display_timeout();
+  timeout_ms = settings_get_display_timeout();
 #if BSP_CAPS_BUTTONS
-    gpio_config_t io_conf = {
-        .pin_bit_mask = 1ULL << DISPLAY_BUTTON,
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    gpio_config(&io_conf);
+  gpio_config_t io_conf = {
+      .pin_bit_mask = 1ULL << DISPLAY_BUTTON,
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  gpio_config(&io_conf);
 #else
-    ESP_LOGI(TAG, "Using PMU PWR key to wake display");
+  ESP_LOGI(TAG, "Using PMU PWR key to wake display");
 #endif
 
-    lv_obj_add_event_cb(lv_scr_act(), touch_event_cb, LV_EVENT_ALL, NULL);
+  lv_obj_add_event_cb(lv_scr_act(), touch_event_cb, LV_EVENT_ALL, NULL);
 
-    // PM lock may be created in early init; if not, create and acquire now
+  // PM lock may be created in early init; if not, create and acquire now
 #if CONFIG_PM_ENABLE
-    if (!s_no_ls_lock) {
-        (void)esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "display", &s_no_ls_lock);
-    }
-    if (s_no_ls_lock) {
-        (void)esp_pm_lock_acquire(s_no_ls_lock);
-    }
+  if (!s_no_ls_lock) {
+    (void)esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "display",
+                             &s_no_ls_lock);
+  }
+  if (s_no_ls_lock) {
+    (void)esp_pm_lock_acquire(s_no_ls_lock);
+  }
 #endif
 
-    // Configure GPIO wake-ups so user input can wake CPU from light sleep
-    // Only meaningful if PM/light-sleep is enabled in project config
+  // Configure GPIO wake-ups so user input can wake CPU from light sleep
+  // Only meaningful if PM/light-sleep is enabled in project config
 #if CONFIG_PM_ENABLE
-    // Touch INT is active-low on this board
-    gpio_config_t touch_io = {
-        .pin_bit_mask = 1ULL << BSP_LCD_TOUCH_INT,
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    (void)gpio_config(&touch_io);
-    (void)gpio_wakeup_enable(BSP_LCD_TOUCH_INT, GPIO_INTR_LOW_LEVEL);
+  // Touch INT is active-low on this board
+  gpio_config_t touch_io = {
+      .pin_bit_mask = 1ULL << BSP_LCD_TOUCH_INT,
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  (void)gpio_config(&touch_io);
+  (void)gpio_wakeup_enable(BSP_LCD_TOUCH_INT, GPIO_INTR_LOW_LEVEL);
 #ifdef CONFIG_PMU_INTERRUPT_PIN
-    // PMU IRQ (e.g., power key) also active-low
-    gpio_config_t pmu_io = {
-        .pin_bit_mask = 1ULL << CONFIG_PMU_INTERRUPT_PIN,
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    (void)gpio_config(&pmu_io);
-    (void)gpio_wakeup_enable(CONFIG_PMU_INTERRUPT_PIN, GPIO_INTR_LOW_LEVEL);
+  // PMU IRQ (e.g., power key) also active-low
+  gpio_config_t pmu_io = {
+      .pin_bit_mask = 1ULL << CONFIG_PMU_INTERRUPT_PIN,
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  (void)gpio_config(&pmu_io);
+  (void)gpio_wakeup_enable(CONFIG_PMU_INTERRUPT_PIN, GPIO_INTR_LOW_LEVEL);
 #endif
-    (void)esp_sleep_enable_gpio_wakeup();
+  (void)esp_sleep_enable_gpio_wakeup();
 #endif // CONFIG_PM_ENABLE
 
-    xTaskCreate(display_manager_task, "display_mgr", 4000, NULL, 4, NULL);
+  // Higher priority so UI updates aren't delayed by other workloads
+  xTaskCreate(display_manager_task, "display_mgr", 4000, NULL, 5, NULL);
 }
 
-void display_manager_pm_early_init(void)
-{
+void display_manager_pm_early_init(void) {
 #if CONFIG_PM_ENABLE
-    if (!s_no_ls_lock) {
-        (void)esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "display", &s_no_ls_lock);
-    }
-    if (s_no_ls_lock) {
-        (void)esp_pm_lock_acquire(s_no_ls_lock);
-    }
+  if (!s_no_ls_lock) {
+    (void)esp_pm_lock_create(ESP_PM_NO_LIGHT_SLEEP, 0, "display",
+                             &s_no_ls_lock);
+  }
+  if (s_no_ls_lock) {
+    (void)esp_pm_lock_acquire(s_no_ls_lock);
+  }
 #else
-    // No power management; nothing to do
-    (void)0;
+  // No power management; nothing to do
+  (void)0;
 #endif
 }
-

--- a/components/gui/src/ui.c
+++ b/components/gui/src/ui.c
@@ -1,232 +1,226 @@
 #include "ui.h"
-#include "watchface.h"
-#include "steps_screen.h"
-#include "notifications.h"
-#include "settings_screen.h"
-#include "sensors.h"
-#include "display_manager.h"
-#include "watchface.h"
+#include "ble_sync.h"
+#include "bsp/esp-bsp.h"
 #include "bsp/esp32_s3_touch_amoled_2_06.h"
+#include "display_manager.h"
 #include "esp_event.h"
+#include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "esp_log.h"
-#include "bsp/esp-bsp.h"
 #include "lvgl.h"
-#include "ble_sync.h"
+#include "notifications.h"
+#include "sensors.h"
+#include "settings_screen.h"
+#include "steps_screen.h"
 #include "ui_fonts.h"
+#include "watchface.h"
 
 #include "batt_screen.h"
-#include "lvgl_spiffs_fs.h"
-#include "driver/gpio.h"
 #include "bsp/esp32_s3_touch_amoled_2_06.h"
+#include "driver/gpio.h"
+#include "lvgl_spiffs_fs.h"
 
-static const char* TAG = "UI";
+static const char *TAG = "UI";
 
-static lv_obj_t* active_screen;
+static lv_obj_t *active_screen;
 static volatile bool s_back_busy = false;
-static void clear_back_busy_cb(lv_timer_t* t)
-{
-    (void)t;
-    s_back_busy = false;
+static void clear_back_busy_cb(lv_timer_t *t) {
+  (void)t;
+  s_back_busy = false;
 }
-//static lv_obj_t* mainTileView;
+// static lv_obj_t* mainTileView;
 
-//lv_obj_t* tileClock;
-//lv_obj_t* tileConfig;
-//lv_obj_t* tileSteps;
-//lv_obj_t* tileMotfication;
+// lv_obj_t* tileClock;
+// lv_obj_t* tileConfig;
+// lv_obj_t* tileSteps;
+// lv_obj_t* tileMotfication;
 
-
-//lv_obj_t* ui_Config_Panel;
-//lv_obj_t* ui_Steps_Panel;
-//lv_obj_t* ui_Messages_Panel;
+// lv_obj_t* ui_Config_Panel;
+// lv_obj_t* ui_Steps_Panel;
+// lv_obj_t* ui_Messages_Panel;
 
 static lv_style_t main_style;
 
 void init_theme(void) {
 
-    lv_style_init(&main_style);
-    lv_style_set_text_color(&main_style, lv_color_white());
-    lv_style_set_bg_color(&main_style, lv_color_black());
-    lv_style_set_border_color(&main_style, lv_color_black());
-    //lv_style_set_bg_opa(&main_style, LV_OPA_100);
-
+  lv_style_init(&main_style);
+  lv_style_set_text_color(&main_style, lv_color_white());
+  lv_style_set_bg_color(&main_style, lv_color_black());
+  lv_style_set_border_color(&main_style, lv_color_black());
+  // lv_style_set_bg_opa(&main_style, LV_OPA_100);
 }
 
-lv_style_t* ui_get_main_style(void)
-{
-    return &main_style;
-}
+lv_style_t *ui_get_main_style(void) { return &main_style; }
 
-void load_screen(lv_obj_t* current_screen, lv_obj_t* next_screen, lv_screen_load_anim_t anim) {
+void load_screen(lv_obj_t *current_screen, lv_obj_t *next_screen,
+                 lv_screen_load_anim_t anim) {
 
-    if (active_screen != next_screen) {
-        //bsp_display_lock(0);
-        lv_screen_load_anim(next_screen, anim, 200, 0, false);
-        active_screen = next_screen;
-        //bsp_display_unlock();
-        /*if (current_screen) {
-            // Delete asynchronously to avoid heavy work in refresh/event context
-            lv_obj_del_async(current_screen);
-        }*/
-    }
+  if (active_screen != next_screen) {
+    // bsp_display_lock(0);
+    lv_screen_load_anim(next_screen, anim, 200, 0, false);
+    active_screen = next_screen;
+    // bsp_display_unlock();
+    /*if (current_screen) {
+        // Delete asynchronously to avoid heavy work in refresh/event context
+        lv_obj_del_async(current_screen);
+    }*/
+  }
 };
 
-lv_obj_t* active_screen_get(void)
-{
-    return active_screen;
-}
+lv_obj_t *active_screen_get(void) { return active_screen; }
 
 void create_main_screen(void) {
 
-    watchface_create();
-    steps_screen_create();
-    notifications_screen_create();
-    control_screen_create();
+  watchface_create();
+  steps_screen_create();
+  notifications_screen_create();
+  control_screen_create();
 
-    load_screen(NULL, watchface_screen_get(), LV_SCR_LOAD_ANIM_NONE);
+  load_screen(NULL, watchface_screen_get(), LV_SCR_LOAD_ANIM_NONE);
 }
 
-void ui_show_messages_tile(void)
-{
-    load_screen(NULL, notifications_screen_get(), LV_SCR_LOAD_ANIM_OVER_TOP);
+void ui_show_messages_tile(void) {
+  load_screen(NULL, notifications_screen_get(), LV_SCR_LOAD_ANIM_OVER_TOP);
 }
-
 
 void ui_init(void) {
-    bsp_display_lock(0);
+  bsp_display_lock(0);
 
-    init_theme();
+  init_theme();
 
-    // Register LVGL FS driver for SPIFFS before any file-based widgets
-    lvgl_spiffs_fs_register();
+  // Register LVGL FS driver for SPIFFS before any file-based widgets
+  lvgl_spiffs_fs_register();
 
-    create_main_screen();
+  create_main_screen();
 
-    {
-        bool vbus = bsp_power_is_vbus_in();
-        bool chg = bsp_power_is_charging();
-        int  pct = bsp_power_get_battery_percent();
-        watchface_set_power_state(vbus, chg, pct);
-    }
+  {
+    bool vbus = bsp_power_is_vbus_in();
+    bool chg = bsp_power_is_charging();
+    int pct = bsp_power_get_battery_percent();
+    watchface_set_power_state(vbus, chg, pct);
+  }
 
-    // Sensors are initialized and task started in main. Avoid duplicating here.
+  // Sensors are initialized and task started in main. Avoid duplicating here.
 
-    bsp_display_unlock();
+  bsp_display_unlock();
 }
 
 // Hardware back button (GPIO0) handler
 #define UI_BACK_BTN GPIO_NUM_0
 
-static void ui_handle_back_async(void* user)
-{
-    (void)user;
+static void ui_handle_back_async(void *user) {
+  (void)user;
 
-    lv_obj_t* scr = lv_scr_act();
-    if (!scr) return;
-    // If already at main tile, do nothing
-    if (scr == watchface_screen_get()) return;
+  lv_obj_t *scr = lv_scr_act();
+  if (!scr)
+    return;
+  // If already at main tile, do nothing
+  if (scr == watchface_screen_get())
+    return;
 
-    load_screen(NULL, watchface_screen_get(), LV_SCR_LOAD_ANIM_OVER_TOP);
-
+  load_screen(NULL, watchface_screen_get(), LV_SCR_LOAD_ANIM_OVER_TOP);
 }
 
-static void ui_back_btn_task(void* arg)
-{
-    (void)arg;
-    // Configure GPIO0 as input with pull-up
-    gpio_config_t io = {
-        .pin_bit_mask = 1ULL << UI_BACK_BTN,
-        .mode = GPIO_MODE_INPUT,
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        .intr_type = GPIO_INTR_DISABLE,
-    };
-    (void)gpio_config(&io);
-    int idle = gpio_get_level(UI_BACK_BTN); // consider this the idle (unpressed) level
-    int prev = idle;
-    TickType_t last_press = 0;
-    const TickType_t debounce = pdMS_TO_TICKS(120);
-    for (;;) {
-        int lvl = gpio_get_level(UI_BACK_BTN);
-        if (prev != lvl) {
-            prev = lvl;
-            // Treat a press as a transition away from idle level (works for active-low or active-high)
-            if (lvl != idle) {
-                TickType_t now = xTaskGetTickCount();
-                if (now - last_press > debounce) {
-                    last_press = now;
-                    // Dispatch back action on LVGL thread
-                    lv_async_call(ui_handle_back_async, NULL);
-                }
-            }
+static void ui_back_btn_task(void *arg) {
+  (void)arg;
+  // Configure GPIO0 as input with pull-up
+  gpio_config_t io = {
+      .pin_bit_mask = 1ULL << UI_BACK_BTN,
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_DISABLE,
+  };
+  (void)gpio_config(&io);
+  int idle =
+      gpio_get_level(UI_BACK_BTN); // consider this the idle (unpressed) level
+  int prev = idle;
+  TickType_t last_press = 0;
+  const TickType_t debounce = pdMS_TO_TICKS(120);
+  TickType_t last = xTaskGetTickCount();
+  for (;;) {
+    int lvl = gpio_get_level(UI_BACK_BTN);
+    if (prev != lvl) {
+      prev = lvl;
+      // Treat a press as a transition away from idle level (works for
+      // active-low or active-high)
+      if (lvl != idle) {
+        TickType_t now = xTaskGetTickCount();
+        if (now - last_press > debounce) {
+          last_press = now;
+          // Dispatch back action on LVGL thread
+          lv_async_call(ui_handle_back_async, NULL);
         }
-        // When screen is ON, allow PMU power button short-press to act as Back.
-        // Do NOT consume it when screen is OFF to preserve wake behavior.
-        if (display_manager_is_on()) {
-            if (bsp_power_poll_pwr_button_short()) {
-                lv_async_call(ui_handle_back_async, NULL);
-            }
-        }
-        vTaskDelay(pdMS_TO_TICKS(20));
+      }
     }
+    // When screen is ON, allow PMU power button short-press to act as Back.
+    // Do NOT consume it when screen is OFF to preserve wake behavior.
+    if (display_manager_is_on()) {
+      if (bsp_power_poll_pwr_button_short()) {
+        lv_async_call(ui_handle_back_async, NULL);
+      }
+    }
+    vTaskDelayUntil(&last, pdMS_TO_TICKS(20));
+  }
 }
 
 // Callback de eventos de energia (file-scope, não aninhada)
-static void power_ui_evt(void* handler_arg, esp_event_base_t base, int32_t id, void* event_data)
-{
-    (void)handler_arg;
-    (void)base;
-    (void)id;
-    bsp_power_event_payload_t* pl = (bsp_power_event_payload_t*)event_data;
-    if (pl && bsp_display_lock(10)) {
-        int pct = bsp_power_get_battery_percent();
-        watchface_set_power_state(pl->vbus_in, pl->charging, pct);
-        bsp_display_unlock();
-    }
+static void power_ui_evt(void *handler_arg, esp_event_base_t base, int32_t id,
+                         void *event_data) {
+  (void)handler_arg;
+  (void)base;
+  (void)id;
+  bsp_power_event_payload_t *pl = (bsp_power_event_payload_t *)event_data;
+  if (pl && bsp_display_lock(10)) {
+    int pct = bsp_power_get_battery_percent();
+    watchface_set_power_state(pl->vbus_in, pl->charging, pct);
+    bsp_display_unlock();
+  }
 }
 
 // Callback BLE: atualiza ícone de ligação
-static void ble_ui_evt(void* handler_arg, esp_event_base_t base, int32_t id, void* event_data)
-{
-    (void)handler_arg; (void)base; (void)event_data;
-    bool connected = (id == BLE_SYNC_EVT_CONNECTED);
-    if (bsp_display_lock(10)) {
-        watchface_set_ble_connected(connected);
-        bsp_display_unlock();
-    }
+static void ble_ui_evt(void *handler_arg, esp_event_base_t base, int32_t id,
+                       void *event_data) {
+  (void)handler_arg;
+  (void)base;
+  (void)event_data;
+  bool connected = (id == BLE_SYNC_EVT_CONNECTED);
+  if (bsp_display_lock(10)) {
+    watchface_set_ble_connected(connected);
+    bsp_display_unlock();
+  }
 }
 
 // Timer callback: periodic power refresh
-static void power_poll_cb(lv_timer_t* t)
-{
-    (void)t;
-    bool vbus = bsp_power_is_vbus_in();
-    bool chg = bsp_power_is_charging();
-    int  pct = bsp_power_get_battery_percent();
-    if (bsp_display_lock(10)) {
-        watchface_set_power_state(vbus, chg, pct);
-        bsp_display_unlock();
-    }
+static void power_poll_cb(lv_timer_t *t) {
+  (void)t;
+  bool vbus = bsp_power_is_vbus_in();
+  bool chg = bsp_power_is_charging();
+  int pct = bsp_power_get_battery_percent();
+  if (bsp_display_lock(10)) {
+    watchface_set_power_state(vbus, chg, pct);
+    bsp_display_unlock();
+  }
 }
 
-void ui_task(void* pvParameters) {
-    ESP_LOGI(TAG, "UI task started");
-    ui_init();
-    display_manager_init();
-    // Subscrever eventos de energia e atualizar UI
-    esp_event_handler_register(BSP_POWER_EVENT_BASE, ESP_EVENT_ANY_ID, power_ui_evt, NULL);
-    esp_event_handler_register(BLE_SYNC_EVENT_BASE, ESP_EVENT_ANY_ID, ble_ui_evt, NULL);
+void ui_task(void *pvParameters) {
+  ESP_LOGI(TAG, "UI task started");
+  ui_init();
+  display_manager_init();
+  // Subscrever eventos de energia e atualizar UI
+  esp_event_handler_register(BSP_POWER_EVENT_BASE, ESP_EVENT_ANY_ID,
+                             power_ui_evt, NULL);
+  esp_event_handler_register(BLE_SYNC_EVENT_BASE, ESP_EVENT_ANY_ID, ble_ui_evt,
+                             NULL);
 
-    // Start back button poller
-    xTaskCreate(ui_back_btn_task, "ui_back_btn", 2048, NULL, 4, NULL);
+  // Start back button poller with a higher priority for snappier input
+  xTaskCreate(ui_back_btn_task, "ui_back_btn", 2048, NULL, 5, NULL);
 
-    // Periodic fallback: refresh power state every 5s in case no events fire
-    lv_timer_t* t = lv_timer_create(power_poll_cb, 5000, NULL);
-    // Trigger once immediately to avoid initial 0%
-    lv_timer_ready(t);
-    while (1) {
-        vTaskDelay(pdMS_TO_TICKS(50));
-    }
+  // Periodic fallback: refresh power state every 5s in case no events fire
+  lv_timer_t *t = lv_timer_create(power_poll_cb, 5000, NULL);
+  // Trigger once immediately to avoid initial 0%
+  lv_timer_ready(t);
+  while (1) {
+    vTaskDelay(pdMS_TO_TICKS(100));
+  }
 }

--- a/components/sensors/sensors.c
+++ b/components/sensors/sensors.c
@@ -1,27 +1,27 @@
 // QMI8658-based step counting and activity classification with raise-to-wake
 
 #include "sensors.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/semphr.h"
+#include "bsp/esp32_s3_touch_amoled_2_06.h"
+#include "display_manager.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
-#include "bsp/esp32_s3_touch_amoled_2_06.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
 #include "qmi8658.h"
-#include "display_manager.h"
 #include <math.h>
 #include <time.h>
-#include "esp_timer.h"
 
-#define IMU_IRQ_GPIO           GPIO_NUM_21
-#define IMU_ADDR_HIGH          QMI8658_ADDRESS_HIGH
-#define IMU_ADDR_LOW           QMI8658_ADDRESS_LOW
+#define IMU_IRQ_GPIO GPIO_NUM_21
+#define IMU_ADDR_HIGH QMI8658_ADDRESS_HIGH
+#define IMU_ADDR_LOW QMI8658_ADDRESS_LOW
 
 // Raise-to-wake sensitivity (tune to taste)
-#define RAISE_DP_THRESH_DEG    55.0f   // min pitch delta to consider a raise
-#define RAISE_ACCEL_MIN_MG     850.0f  // acceptable accel magnitude lower bound
-#define RAISE_ACCEL_MAX_MG     1150.0f // acceptable accel magnitude upper bound
-#define RAISE_COOLDOWN_MS      3500    // min ms between wakeups
+#define RAISE_DP_THRESH_DEG 55.0f  // min pitch delta to consider a raise
+#define RAISE_ACCEL_MIN_MG 850.0f  // acceptable accel magnitude lower bound
+#define RAISE_ACCEL_MAX_MG 1150.0f // acceptable accel magnitude upper bound
+#define RAISE_COOLDOWN_MS 3500     // min ms between wakeups
 
 static const char *TAG = "SENSORS";
 
@@ -32,227 +32,237 @@ static sensors_activity_t s_activity = SENSORS_ACTIVITY_IDLE;
 static SemaphoreHandle_t s_wom_sem = NULL; // wake-on-motion semaphore
 static time_t s_last_midnight = 0;
 
-static time_t get_midnight_epoch(time_t now)
-{
-    struct tm tm_now;
-    localtime_r(&now, &tm_now);
-    tm_now.tm_hour = 0; tm_now.tm_min = 0; tm_now.tm_sec = 0;
-    return mktime(&tm_now);
+static time_t get_midnight_epoch(time_t now) {
+  struct tm tm_now;
+  localtime_r(&now, &tm_now);
+  tm_now.tm_hour = 0;
+  tm_now.tm_min = 0;
+  tm_now.tm_sec = 0;
+  return mktime(&tm_now);
 }
 
-static void maybe_reset_daily_counter(void)
-{
-    time_t now = time(NULL);
-    if (s_last_midnight == 0) {
-        s_last_midnight = get_midnight_epoch(now);
-    }
-    time_t midnight_now = get_midnight_epoch(now);
-    if (midnight_now > s_last_midnight) {
-        s_last_midnight = midnight_now;
-        s_step_count = 0;
-        ESP_LOGI(TAG, "Daily step counter reset at midnight");
-    }
+static void maybe_reset_daily_counter(void) {
+  time_t now = time(NULL);
+  if (s_last_midnight == 0) {
+    s_last_midnight = get_midnight_epoch(now);
+  }
+  time_t midnight_now = get_midnight_epoch(now);
+  if (midnight_now > s_last_midnight) {
+    s_last_midnight = midnight_now;
+    s_step_count = 0;
+    ESP_LOGI(TAG, "Daily step counter reset at midnight");
+  }
 }
 
-static void IRAM_ATTR imu_irq_isr(void* arg)
-{
-    BaseType_t hp = pdFALSE;
-    if (s_wom_sem) {
-        xSemaphoreGiveFromISR(s_wom_sem, &hp);
-    }
-    if (hp) portYIELD_FROM_ISR();
+static void IRAM_ATTR imu_irq_isr(void *arg) {
+  BaseType_t hp = pdFALSE;
+  if (s_wom_sem) {
+    xSemaphoreGiveFromISR(s_wom_sem, &hp);
+  }
+  if (hp)
+    portYIELD_FROM_ISR();
 }
 
-static esp_err_t imu_setup_irq(void)
-{
-    gpio_config_t io = {
-        .pin_bit_mask = 1ULL << IMU_IRQ_GPIO,
-        .mode = GPIO_MODE_INPUT,
-        // QMI8658 INT is typically active-low; use pull-up only
-        .pull_up_en = GPIO_PULLUP_ENABLE,
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,
-        // Use falling edge to avoid interrupt storms on level changes/noise
-        .intr_type = GPIO_INTR_NEGEDGE,
-    };
-    ESP_ERROR_CHECK(gpio_config(&io));
-    esp_err_t r = gpio_install_isr_service(0);
-    if (r != ESP_OK && r != ESP_ERR_INVALID_STATE) {
-        return r;
-    }
-    // Clear any pending status before enabling
-    gpio_intr_disable(IMU_IRQ_GPIO);
-    (void)gpio_set_intr_type(IMU_IRQ_GPIO, GPIO_INTR_NEGEDGE);
-    ESP_ERROR_CHECK(gpio_isr_handler_add(IMU_IRQ_GPIO, imu_irq_isr, NULL));
-    gpio_intr_enable(IMU_IRQ_GPIO);
-    return ESP_OK;
+static esp_err_t imu_setup_irq(void) {
+  gpio_config_t io = {
+      .pin_bit_mask = 1ULL << IMU_IRQ_GPIO,
+      .mode = GPIO_MODE_INPUT,
+      // QMI8658 INT is typically active-low; use pull-up only
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      // Use falling edge to avoid interrupt storms on level changes/noise
+      .intr_type = GPIO_INTR_NEGEDGE,
+  };
+  ESP_ERROR_CHECK(gpio_config(&io));
+  esp_err_t r = gpio_install_isr_service(0);
+  if (r != ESP_OK && r != ESP_ERR_INVALID_STATE) {
+    return r;
+  }
+  // Clear any pending status before enabling
+  gpio_intr_disable(IMU_IRQ_GPIO);
+  (void)gpio_set_intr_type(IMU_IRQ_GPIO, GPIO_INTR_NEGEDGE);
+  ESP_ERROR_CHECK(gpio_isr_handler_add(IMU_IRQ_GPIO, imu_irq_isr, NULL));
+  gpio_intr_enable(IMU_IRQ_GPIO);
+  return ESP_OK;
 }
 
-static bool imu_try_init_with_addr(uint8_t addr)
-{
-    i2c_master_bus_handle_t bus = bsp_i2c_get_handle();
-    if (!bus) return false;
-    if (qmi8658_init(&s_imu, bus, addr) != ESP_OK) return false;
-    // Configure for low-power step counting: accel only, ~62.5 Hz, 4g
-    (void)qmi8658_enable_sensors(&s_imu, QMI8658_DISABLE_ALL);
-    (void)qmi8658_set_accel_range(&s_imu, QMI8658_ACCEL_RANGE_4G);
-    (void)qmi8658_set_accel_odr(&s_imu, QMI8658_ACCEL_ODR_62_5HZ);
-    (void)qmi8658_enable_accel(&s_imu, true);
-    qmi8658_set_accel_unit_mg(&s_imu, true); // mg units simplify magnitude
-    return true;
+static bool imu_try_init_with_addr(uint8_t addr) {
+  i2c_master_bus_handle_t bus = bsp_i2c_get_handle();
+  if (!bus)
+    return false;
+  if (qmi8658_init(&s_imu, bus, addr) != ESP_OK)
+    return false;
+  // Configure for low-power step counting: accel only, ~62.5 Hz, 4g
+  (void)qmi8658_enable_sensors(&s_imu, QMI8658_DISABLE_ALL);
+  (void)qmi8658_set_accel_range(&s_imu, QMI8658_ACCEL_RANGE_4G);
+  (void)qmi8658_set_accel_odr(&s_imu, QMI8658_ACCEL_ODR_62_5HZ);
+  (void)qmi8658_enable_accel(&s_imu, true);
+  qmi8658_set_accel_unit_mg(&s_imu, true); // mg units simplify magnitude
+  return true;
 }
 
-void sensors_init(void)
-{
-    ESP_LOGI(TAG, "Initializing sensors (QMI8658)");
-    if (bsp_i2c_init() != ESP_OK) {
-        ESP_LOGE(TAG, "I2C not available");
-        return;
-    }
-    // Try both possible I2C addresses
-    s_imu_ready = imu_try_init_with_addr(IMU_ADDR_HIGH) || imu_try_init_with_addr(IMU_ADDR_LOW);
-    if (!s_imu_ready) {
-        ESP_LOGE(TAG, "QMI8658 init failed");
-        return;
-    }
-    // Create semaphore and IRQ for wake-on-motion
-    s_wom_sem = xSemaphoreCreateBinary();
-    if (s_wom_sem) {
-        imu_setup_irq();
-        // Configure wake-on-motion threshold (LSB depends on FS/ODR; empirical)
-        (void)qmi8658_enable_wake_on_motion(&s_imu, 12); // ~12 LSB ~ few tens of mg
-    }
+void sensors_init(void) {
+  ESP_LOGI(TAG, "Initializing sensors (QMI8658)");
+  if (bsp_i2c_init() != ESP_OK) {
+    ESP_LOGE(TAG, "I2C not available");
+    return;
+  }
+  // Try both possible I2C addresses
+  s_imu_ready = imu_try_init_with_addr(IMU_ADDR_HIGH) ||
+                imu_try_init_with_addr(IMU_ADDR_LOW);
+  if (!s_imu_ready) {
+    ESP_LOGE(TAG, "QMI8658 init failed");
+    return;
+  }
+  // Create semaphore and IRQ for wake-on-motion
+  s_wom_sem = xSemaphoreCreateBinary();
+  if (s_wom_sem) {
+    imu_setup_irq();
+    // Configure wake-on-motion threshold (LSB depends on FS/ODR; empirical)
+    (void)qmi8658_enable_wake_on_motion(&s_imu, 12); // ~12 LSB ~ few tens of mg
+  }
+  maybe_reset_daily_counter();
+}
+
+uint32_t sensors_get_step_count(void) { return s_step_count; }
+
+sensors_activity_t sensors_get_activity(void) { return s_activity; }
+
+void sensors_task(void *pvParameters) {
+  ESP_LOGI(TAG, "Sensors task started");
+  const TickType_t sample_delay_active = pdMS_TO_TICKS(20); // ~50 Hz
+  const TickType_t sample_delay_idle =
+      pdMS_TO_TICKS(40);     // ~25 Hz when screen off
+  float lp = 0.0f;           // filtered magnitude
+  const float alpha = 0.90f; // LP filter smoothing
+  uint32_t last_step_ms = 0;
+  // Ring buffer for cadence (last 8 steps)
+  uint32_t step_ts_ms[8] = {0};
+  int step_ts_idx = 0, step_ts_num = 0;
+  // Raise-to-wake detection state
+  float pitch_hist[16] = {0};
+  uint32_t ts_hist[16] = {0};
+  int hist_idx = 0, hist_num = 0;
+  uint32_t last_raise_ms = 0;
+
+  bool wom_enabled = true; // enabled in init
+  bool ready_for_next_peak = true;
+  TickType_t last = xTaskGetTickCount();
+  while (1) {
     maybe_reset_daily_counter();
-}
 
-uint32_t sensors_get_step_count(void)
-{
-    return s_step_count;
-}
-
-sensors_activity_t sensors_get_activity(void)
-{
-    return s_activity;
-}
-
-void sensors_task(void *pvParameters)
-{
-    ESP_LOGI(TAG, "Sensors task started");
-    const TickType_t sample_delay_active = pdMS_TO_TICKS(20); // ~50 Hz
-    const TickType_t sample_delay_idle   = pdMS_TO_TICKS(40); // ~25 Hz when screen off
-    float lp = 0.0f; // filtered magnitude
-    const float alpha = 0.90f; // LP filter smoothing
-    uint32_t last_step_ms = 0;
-    // Ring buffer for cadence (last 8 steps)
-    uint32_t step_ts_ms[8] = {0};
-    int step_ts_idx = 0, step_ts_num = 0;
-    // Raise-to-wake detection state
-    float pitch_hist[16] = {0};
-    uint32_t ts_hist[16] = {0};
-    int hist_idx = 0, hist_num = 0;
-    uint32_t last_raise_ms = 0;
-
-    bool wom_enabled = true; // enabled in init
-    bool ready_for_next_peak = true;
-    while (1) {
-        maybe_reset_daily_counter();
-
-        // If display is off, enable WoM but also sample levemente para gesto de levantar pulso
-        bool screen_on = display_manager_is_on();
-        if (!screen_on) {
-            if (!wom_enabled && s_imu_ready) {
-                (void)qmi8658_enable_wake_on_motion(&s_imu, 12);
-                wom_enabled = true;
-            }
-            /*if (s_wom_sem && xSemaphoreTake(s_wom_sem, 0) == pdTRUE) {
-                ESP_LOGI(TAG, "Wake-on-motion IRQ");
-                display_manager_turn_on();
-                // skip rest of loop; next iter will run as screen_on
-                vTaskDelay(pdMS_TO_TICKS(50));
-                continue;
-            }*/
-        }
-
-        if (!s_imu_ready) {
-            vTaskDelay(pdMS_TO_TICKS(1000));
-            continue;
-        }
-        // Display is on: prefer normal sampling, disable WoM to avoid extra interrupts
-        if (screen_on && wom_enabled) {
-            (void)qmi8658_disable_wake_on_motion(&s_imu);
-            wom_enabled = false;
-        }
-
-        float ax, ay, az;
-        if (qmi8658_read_accel(&s_imu, &ax, &ay, &az) == ESP_OK) {
-            // ax,ay,az in mg
-            float mag = sqrtf(ax*ax + ay*ay + az*az); // mg
-            float hp = mag - 1000.0f; // remove gravity
-            lp = alpha * lp + (1.0f - alpha) * hp;
-
-            // Peak detection
-            const float THRESH = 80.0f; // mg (more sensitive)
-            uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000ULL);
-            uint32_t dt = now_ms - last_step_ms;
-            if (lp > THRESH && dt > 280 && dt < 2000) {
-                if (ready_for_next_peak) {
-                    s_step_count++;
-                    // cadence buffer
-                    step_ts_ms[step_ts_idx] = now_ms;
-                    step_ts_idx = (step_ts_idx + 1) & 7;
-                    if (step_ts_num < 8) step_ts_num++;
-                    last_step_ms = now_ms;
-                    ready_for_next_peak = false;
-                }
-            } else if (lp < THRESH * 0.5f) {
-                ready_for_next_peak = true;
-            }
-
-            // Classify activity by cadence (last N steps)
-            if (step_ts_num >= 2) {
-                uint32_t oldest = step_ts_ms[(step_ts_idx - step_ts_num + 8) & 7];
-                uint32_t newest = step_ts_ms[(step_ts_idx - 1 + 8) & 7];
-                uint32_t span_ms = newest - oldest;
-                float spm = 0.0f;
-                if (span_ms > 0) {
-                    spm = 60000.0f * (float)(step_ts_num - 1) / (float)span_ms;
-                }
-                if (spm > 130.0f) s_activity = SENSORS_ACTIVITY_RUN;
-                else if (spm > 60.0f) s_activity = SENSORS_ACTIVITY_WALK;
-                else if (spm > 10.0f) s_activity = SENSORS_ACTIVITY_OTHER;
-                else s_activity = SENSORS_ACTIVITY_IDLE;
-            } else {
-                s_activity = SENSORS_ACTIVITY_IDLE;
-            }
-
-            // Raise-to-wake: compute pitch angle from accel (degrees)
-            // pitch ~ rotation around Y: -ax against gravity
-            float ax_g = ax / 1000.0f, ay_g = ay / 1000.0f, az_g = az / 1000.0f;
-            float pitch = (float)(atan2f(-ax_g, sqrtf(ay_g*ay_g + az_g*az_g)) * 180.0f / (float)M_PI);
-            //uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000ULL);
-            pitch_hist[hist_idx] = pitch;
-            ts_hist[hist_idx] = now_ms;
-            hist_idx = (hist_idx + 1) & 15;
-            if (hist_num < 16) hist_num++;
-
-            if (!screen_on) {
-                // Compare with sample ~400-600ms atrás
-                float pitch_prev = pitch;
-                for (int k = 1; k <= hist_num; ++k) {
-                    int idx = (hist_idx - k + 16) & 15;
-                    uint32_t dtms = now_ms - ts_hist[idx];
-                    if (dtms >= 400 && dtms <= 700) { pitch_prev = pitch_hist[idx]; break; }
-                }
-                float dp = pitch - pitch_prev; // positive when lifting display up
-                bool accel_ok = (mag > RAISE_ACCEL_MIN_MG && mag < RAISE_ACCEL_MAX_MG); // avoid big shakes
-                bool cooldown_ok = (now_ms - last_raise_ms) > RAISE_COOLDOWN_MS;
-                if (dp > RAISE_DP_THRESH_DEG && accel_ok && cooldown_ok) {
-                    ESP_LOGI(TAG, "Raise-to-wake: dp=%.1f pitch=%.1f prev=%.1f", dp, pitch, pitch_prev);
-                    last_raise_ms = now_ms;
-                    display_manager_turn_on();
-                    // let next iter process as screen_on
-                }
-            }
-        }
-        vTaskDelay(screen_on ? sample_delay_active : sample_delay_idle);
+    // If display is off, enable WoM but also sample levemente para gesto de
+    // levantar pulso
+    bool screen_on = display_manager_is_on();
+    if (!screen_on) {
+      if (!wom_enabled && s_imu_ready) {
+        (void)qmi8658_enable_wake_on_motion(&s_imu, 12);
+        wom_enabled = true;
+      }
+      /*if (s_wom_sem && xSemaphoreTake(s_wom_sem, 0) == pdTRUE) {
+          ESP_LOGI(TAG, "Wake-on-motion IRQ");
+          display_manager_turn_on();
+          // skip rest of loop; next iter will run as screen_on
+          vTaskDelay(pdMS_TO_TICKS(50));
+          continue;
+      }*/
     }
+
+    if (!s_imu_ready) {
+      vTaskDelay(pdMS_TO_TICKS(1000));
+      continue;
+    }
+    // Display is on: prefer normal sampling, disable WoM to avoid extra
+    // interrupts
+    if (screen_on && wom_enabled) {
+      (void)qmi8658_disable_wake_on_motion(&s_imu);
+      wom_enabled = false;
+    }
+
+    float ax, ay, az;
+    if (qmi8658_read_accel(&s_imu, &ax, &ay, &az) == ESP_OK) {
+      // ax,ay,az in mg
+      float mag = sqrtf(ax * ax + ay * ay + az * az); // mg
+      float hp = mag - 1000.0f;                       // remove gravity
+      lp = alpha * lp + (1.0f - alpha) * hp;
+
+      // Peak detection
+      const float THRESH = 80.0f; // mg (more sensitive)
+      uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000ULL);
+      uint32_t dt = now_ms - last_step_ms;
+      if (lp > THRESH && dt > 280 && dt < 2000) {
+        if (ready_for_next_peak) {
+          s_step_count++;
+          // cadence buffer
+          step_ts_ms[step_ts_idx] = now_ms;
+          step_ts_idx = (step_ts_idx + 1) & 7;
+          if (step_ts_num < 8)
+            step_ts_num++;
+          last_step_ms = now_ms;
+          ready_for_next_peak = false;
+        }
+      } else if (lp < THRESH * 0.5f) {
+        ready_for_next_peak = true;
+      }
+
+      // Classify activity by cadence (last N steps)
+      if (step_ts_num >= 2) {
+        uint32_t oldest = step_ts_ms[(step_ts_idx - step_ts_num + 8) & 7];
+        uint32_t newest = step_ts_ms[(step_ts_idx - 1 + 8) & 7];
+        uint32_t span_ms = newest - oldest;
+        float spm = 0.0f;
+        if (span_ms > 0) {
+          spm = 60000.0f * (float)(step_ts_num - 1) / (float)span_ms;
+        }
+        if (spm > 130.0f)
+          s_activity = SENSORS_ACTIVITY_RUN;
+        else if (spm > 60.0f)
+          s_activity = SENSORS_ACTIVITY_WALK;
+        else if (spm > 10.0f)
+          s_activity = SENSORS_ACTIVITY_OTHER;
+        else
+          s_activity = SENSORS_ACTIVITY_IDLE;
+      } else {
+        s_activity = SENSORS_ACTIVITY_IDLE;
+      }
+
+      // Raise-to-wake: compute pitch angle from accel (degrees)
+      // pitch ~ rotation around Y: -ax against gravity
+      float ax_g = ax / 1000.0f, ay_g = ay / 1000.0f, az_g = az / 1000.0f;
+      float pitch = (float)(atan2f(-ax_g, sqrtf(ay_g * ay_g + az_g * az_g)) *
+                            180.0f / (float)M_PI);
+      // uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000ULL);
+      pitch_hist[hist_idx] = pitch;
+      ts_hist[hist_idx] = now_ms;
+      hist_idx = (hist_idx + 1) & 15;
+      if (hist_num < 16)
+        hist_num++;
+
+      if (!screen_on) {
+        // Compare with sample ~400-600ms atrás
+        float pitch_prev = pitch;
+        for (int k = 1; k <= hist_num; ++k) {
+          int idx = (hist_idx - k + 16) & 15;
+          uint32_t dtms = now_ms - ts_hist[idx];
+          if (dtms >= 400 && dtms <= 700) {
+            pitch_prev = pitch_hist[idx];
+            break;
+          }
+        }
+        float dp = pitch - pitch_prev; // positive when lifting display up
+        bool accel_ok = (mag > RAISE_ACCEL_MIN_MG &&
+                         mag < RAISE_ACCEL_MAX_MG); // avoid big shakes
+        bool cooldown_ok = (now_ms - last_raise_ms) > RAISE_COOLDOWN_MS;
+        if (dp > RAISE_DP_THRESH_DEG && accel_ok && cooldown_ok) {
+          ESP_LOGI(TAG, "Raise-to-wake: dp=%.1f pitch=%.1f prev=%.1f", dp,
+                   pitch, pitch_prev);
+          last_raise_ms = now_ms;
+          display_manager_turn_on();
+          // let next iter process as screen_on
+        }
+      }
+    }
+    TickType_t delay = screen_on ? sample_delay_active : sample_delay_idle;
+    vTaskDelayUntil(&last, delay);
+  }
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,18 +1,18 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#include "bsp/display.h"
+#include "bsp/esp-bsp.h"
+#include "bsp_board_extra.h"
+#include "display_manager.h"
 #include "esp_check.h"
 #include "esp_err.h"
+#include "esp_event.h"
 #include "esp_log.h"
 #include "lvgl.h"
-#include "bsp/esp-bsp.h"
-#include "bsp/display.h"
-#include "bsp_board_extra.h"
 #include "sensors.h"
 #include "settings.h"
 #include "ui.h"
-#include "display_manager.h"
-#include "esp_event.h"
 // Power management
 #include "esp_pm.h"
 // UI/BLE reagem a eventos de energia; remover ponte direta aqui
@@ -21,42 +21,44 @@
 static const char *TAG = "MAIN";
 
 extern "C" void app_main(void) {
-    
-    //esp_log_level_set("lcd_panel.io.spi", ESP_LOG_DEBUG);
-    
-    // Create default event loop for component event handlers
-    esp_event_loop_create_default();
 
-    // Block light-sleep during boot and UI/display bring-up
-    display_manager_pm_early_init();
+  // esp_log_level_set("lcd_panel.io.spi", ESP_LOG_DEBUG);
 
-    // Enable Dynamic Frequency Scaling + automatic light sleep so CPU idles low
-    // BLE remains active; display_manager controls light-sleep via a PM lock
-    // Defer PM config until after BSP and BLE init
+  // Create default event loop for component event handlers
+  esp_event_loop_create_default();
 
-    bsp_display_start();
+  // Block light-sleep during boot and UI/display bring-up
+  display_manager_pm_early_init();
 
-    bsp_extra_init();
+  // Enable Dynamic Frequency Scaling + automatic light sleep so CPU idles low
+  // BLE remains active; display_manager controls light-sleep via a PM lock
+  // Defer PM config until after BSP and BLE init
 
-    settings_init();
+  bsp_display_start();
 
-    // Play a subtle startup tone once the system is up
-    audio_alert_play_startup();
+  bsp_extra_init();
 
-    // UI task chama display_manager_init() após criar o ecrã
+  settings_init();
 
-    // UI e BLE subscrevem eventos diretamente; sem acoplamento no main
+  // Play a subtle startup tone once the system is up
+  audio_alert_play_startup();
 
-    sensors_init();
+  // UI task chama display_manager_init() após criar o ecrã
 
-    xTaskCreate(ui_task, "ui", 8000, NULL, 4, NULL);
-    xTaskCreate(sensors_task, "sensors", 4096, NULL, 4, NULL);
+  // UI e BLE subscrevem eventos diretamente; sem acoplamento no main
 
-    // Now enable PM with light sleep allowed (still blocked while screen is ON)
-    esp_pm_config_t pm_cfg = {
-        .max_freq_mhz = 240,
-        .min_freq_mhz = 80,
-        .light_sleep_enable = true,
-    };
-    (void)esp_pm_configure(&pm_cfg);
+  sensors_init();
+
+  // Run the UI at a slightly higher priority so LVGL remains responsive
+  xTaskCreate(ui_task, "ui", 8000, NULL, 5, NULL);
+  // Sensor sampling can run at a lower priority without affecting UX
+  xTaskCreate(sensors_task, "sensors", 4096, NULL, 3, NULL);
+
+  // Now enable PM with light sleep allowed (still blocked while screen is ON)
+  esp_pm_config_t pm_cfg = {
+      .max_freq_mhz = 240,
+      .min_freq_mhz = 80,
+      .light_sleep_enable = true,
+  };
+  (void)esp_pm_configure(&pm_cfg);
 }


### PR DESCRIPTION
## Summary
- raise UI and display manager task priorities to keep LVGL responsive
- lower sensor task priority and use periodic waits to reduce CPU usage
- poll hardware buttons with vTaskDelayUntil for steady timing

## Testing
- `idf.py build` *(fails: cmake process terminated while fetching submodules)*

------
https://chatgpt.com/codex/tasks/task_e_68b091b4a1788332a6f0c5e7c0756236